### PR TITLE
reconstruct_cluster_from_config_dump: Fix UUID creation

### DIFF
--- a/ctools/reconstruct_cluster_from_config_dump.py
+++ b/ctools/reconstruct_cluster_from_config_dump.py
@@ -270,7 +270,7 @@ def main():
             }
 
             if collUUID:
-                applyOpsCommand['ui'] = collUUID
+                applyOpsCommand['applyOps'][0]['ui'] = collUUID
 
             config.log_line("db.adminCommand(" + str(applyOpsCommand) + ");")
             db.command(applyOpsCommand, codec_options=CodecOptions(uuid_representation=4))


### PR DESCRIPTION
Fix an issue introduced in c59869e7ae71ec6d3b0e0d78978c2f5be4a0135a
 'Make reconstruct_cluster_from_config_dump.py ignore missing UUIDs'

The issue causes different UUID's for the same collection to be
created on shards.

Incorrect UUID field in c59869e7ae71e:
  {'applyOps': [{'op': '', 'ns': '', 'o': {'create': ''}}], 'ui': UUID()}

Correct UUID field:
  {'applyOps': [{'op': '', 'ns': '', 'o': {'create': ''}, 'ui': UUID()}]}