### PR TITLE
Throttle subsequent migrations according to script argument

### DIFF
--- a/ctools/defragment_sharded_collection.py
+++ b/ctools/defragment_sharded_collection.py
@@ -687,6 +687,7 @@ async def main(args):
                     num_chunks -= 1
                     num_small_chunks -= 1
                     await exec_throttle()
+                    begin_time = time.monotonic()
                     continue
             
             if right_chunk is not None:
@@ -719,6 +720,7 @@ async def main(args):
                     num_chunks -= 1
                     num_small_chunks -= 1
                     await exec_throttle()
+                    begin_time = time.monotonic()
                     continue
         # </for c in sorted_chunks:>
         return total_moved_data_kb


### PR DESCRIPTION
The begin time must be re-initialized after each migration, otherwise every migration of the [loop](https://github.com/kaloianm/workscripts/blob/4de22264d2d9b9b328951c46e7f126d317d6a760/ctools/defragment_sharded_collection.py#L619) after the first will not be throttled