### PR TITLE
Make phase1 idempotent

### DIFF
--- a/ctools/defragment_sharded_collection.py
+++ b/ctools/defragment_sharded_collection.py
@@ -438,8 +438,8 @@ async def main(args):
 
             merge_consecutive_chunks_without_size_check = False
 
-            if consecutive_chunks.batch[-1]['max'] == c['min']:
-                consecutive_chunks.append(c)
+            if consecutive_chunks.batch[-1]['max'] == c['min'] and not ( consecutive_chunks.trust_batch_estimation and 'defrag_collection_est_size' in c and consecutive_chunks.batch_size_estimation + c['defrag_collection_est_size'] > (target_chunk_size_kb * 1.20)):
+                    consecutive_chunks.append(c)
             elif len(consecutive_chunks) == 1:
                 await update_chunk_size_estimation(consecutive_chunks.batch[0])
                 remain_chunks.append(consecutive_chunks.batch[0])


### PR DESCRIPTION

- **First commit**: So the first commit is just a refactoring... I'm not really proud of this implementation, I could have avoided the introduction of the class, but since the code is already pretty complicated I decided to hide the size estimation logic behind the `ChunkBatch` class.
- **Second commit**: This is the actual fix to make phase 1 idempotent. The idea is the following: if we
  -  (A) trust the size estimation of the range in `consecutive_chunks` and
  -  (B) we already calculated the the size of the current chunk (`c`)
 
 then we shouldn't blindly add `c` to the `consecutive_chunks` batch, but rather use the calculated size to check if the resulting merged chunk would be to big. If this is the case than keep it separated from the previous batch and merge only the chunks in `consecutive_chunks` array.

An additional commit with decorating comments is on its way 🚜 