### PR TITLE
Add supoort for defragmenting MongoDB 5.0 clusters

### DIFF
--- a/ctools/common.py
+++ b/ctools/common.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 
 from pymongo import uri_parser
+from bson.codec_options import CodecOptions
+from bson.binary import UuidRepresentation
 
 
 # Function for a Yes/No result based on the answer provided as an argument
@@ -40,7 +42,8 @@ class Cluster:
         self.client = motor.motor_asyncio.AsyncIOMotorClient(uri)
 
         self.adminDb = self.client.admin
-        self.configDb = self.client.config
+        std_codec_options = CodecOptions(uuid_representation=UuidRepresentation.STANDARD)
+        self.configDb = self.client.get_database('config', codec_options=std_codec_options)
 
     class NotMongosException(Exception):
         pass


### PR DESCRIPTION
In 5.0 the format of both `config.collections` and `config.chunks` changed. In #72 I added support for generating sharded collection with the new format and in this PR I'm adding support for running the defragmentation script in 5.0 cluster.
In particular if we are 5.0 we need to target `config.chunks` entries by `uuid` rather then `ns`. 