### PR TITLE
Baseline workload overlay + analysis improvements

### DIFF
--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -305,7 +305,7 @@ def main():
     def _x_axis(ax, max_elapsed_h):
         bucket_h = args.bucket_minutes / 60
         major_h = max(bucket_h, round(max_elapsed_h / 10 / bucket_h + 0.5) * bucket_h)
-        ax.set_xlim(left=0)
+        ax.set_xlim(left=0, right=max_elapsed_h)
         ax.xaxis.set_major_locator(plt.MultipleLocator(major_h))
         ax.xaxis.set_minor_locator(plt.MultipleLocator(bucket_h))
         ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x:g}h'))
@@ -439,7 +439,7 @@ def main():
                             columns=['percentile', 'phase', 'experiment', 'bin_left', 'bin_right',
                                      'count'])
 
-    def _make_latency_figure(label, df):
+    def _make_latency_figure(label, df, y_max=None):
         exp_names = [c.split(' / ', 1)[1] for c in df.columns if c.startswith(f'{label} /')]
 
         fig, ax = plt.subplots(figsize=(16, 6))
@@ -456,7 +456,7 @@ def main():
 
         linear_threshold = 250
         ax.set_yscale('symlog', linthresh=linear_threshold, linscale=1)
-        ax.set_ylim(bottom=0)
+        ax.set_ylim(bottom=0, top=y_max)
         ax.axhline(linear_threshold, color='gray', linestyle=':', linewidth=0.8, alpha=0.6)
 
         fig.canvas.draw()
@@ -553,6 +553,13 @@ def main():
             ax.legend(fontsize=8)
 
         fig.canvas.draw()
+        global_xmax = max(ax.get_xlim()[1] for ax in axes)
+        global_ymax = max(ax.get_ylim()[1] for ax in axes)
+        for ax in axes:
+            ax.set_xlim(right=global_xmax)
+            ax.set_ylim(top=global_ymax)
+
+        fig.canvas.draw()
         for ax in axes:
             xticks = sorted(set(t for t in ax.get_xticks() if t >= 0) | {float(x_threshold)})
             ax.xaxis.set_major_locator(FixedLocator(xticks))
@@ -603,11 +610,14 @@ def main():
             ftdc_prefixes.append(parts[0])
             seen_prefixes.add(parts[0])
 
+    lat_cols = [c for c in df_plot.columns if any(c.startswith(f'{lbl} /') for _, lbl in metrics)]
+    global_lat_ymax = float(df_plot[lat_cols].max().max()) if lat_cols else None
+
     if args.fmt == 'pdf':
         out_path = 'locust_latency.pdf'
         with PdfPages(out_path) as pdf:
             for _, label in metrics:
-                fig = _make_latency_figure(label, df_plot)
+                fig = _make_latency_figure(label, df_plot, y_max=global_lat_ymax)
                 pdf.savefig(fig, dpi=150)
                 plt.close(fig)
             for metric_prefix in ftdc_prefixes:
@@ -617,7 +627,7 @@ def main():
         print(f'Saved: {out_path}')
     else:
         for _, label in metrics:
-            fig = _make_latency_figure(label, df_plot)
+            fig = _make_latency_figure(label, df_plot, y_max=global_lat_ymax)
             out_path = f'locust_latency_{label.lower()}.{args.fmt}'
             fig.savefig(out_path, dpi=150)
             plt.close(fig)

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -506,7 +506,6 @@ def main():
             ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{int(x):,}'))
             ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda y, _: f'{int(y):,}'))
 
-        fig.suptitle(f'Latency Histograms by Phase — {args.request_name}', fontsize=13)
         fig.tight_layout()
         return fig
 

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -493,7 +493,8 @@ def main():
             ax.set_xscale('symlog', linthresh=x_threshold, linscale=1)
             ax.set_xlim(left=0)
             ax.axvline(x_threshold, color='gray', linestyle=':', linewidth=0.8, alpha=0.6)
-            ax.set_ylim(bottom=0)
+            ax.set_yscale('log')
+            ax.set_ylim(bottom=0.9)
             ax.legend(fontsize=8)
 
         fig.canvas.draw()

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -355,8 +355,6 @@ def main():
                     if not subset.empty:
                         phase_subsets.setdefault(pname, []).append(subset)
                 for pname, subsets in phase_subsets.items():
-                    if pname.lower() == 'warmup':
-                        continue
                     combined = pd.concat(subsets) if len(subsets) > 1 else subsets[0]
                     groups.append((combined, exp_name, pname))
 

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -248,12 +248,14 @@ def main():
     warmup_dir = getattr(args, 'warmup', None)
     warmup_dir_norm = os.path.normpath(warmup_dir) if warmup_dir else None
 
+    exp_dirs = list(args.experiments)
+    if warmup_dir_norm and not any(os.path.normpath(d) == warmup_dir_norm for d in exp_dirs):
+        exp_dirs.insert(0, warmup_dir)
+
     experiments = {}
     experiments_raw = {}
     experiment_t0s = {}
-    for exp_dir in args.experiments:
-        if warmup_dir_norm and os.path.normpath(exp_dir) == warmup_dir_norm:
-            continue  # loaded separately as baseline
+    for exp_dir in exp_dirs:
         name = os.path.basename(exp_dir.rstrip('/\\'))
         print(f'Loading {name} ...')
         df, t0 = load_experiment(exp_dir, args.request_name)
@@ -272,8 +274,6 @@ def main():
     ftdc_by_exp = {}
     if ftdc_substrings:
         for exp_dir in args.experiments:
-            if warmup_dir_norm and os.path.normpath(exp_dir) == warmup_dir_norm:
-                continue
             name = os.path.basename(exp_dir.rstrip('/\\'))
             print(f'Loading FTDC for {name} ...')
             try:
@@ -286,8 +286,6 @@ def main():
     # Parse phase start/end times from operation logs
     experiment_phases = {}
     for exp_dir in args.experiments:
-        if warmup_dir_norm and os.path.normpath(exp_dir) == warmup_dir_norm:
-            continue
         name = os.path.basename(exp_dir.rstrip('/\\'))
         t0 = experiment_t0s[name]
         experiment_phases[name] = [(pname, (s - t0) / 3600.0,

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -336,7 +336,7 @@ def main():
         long-format DataFrame with columns [percentile, phase, experiment, bin_left, bin_right,
         count].  phase='all' means no phase info (all data combined).
         """
-        percentiles = [('50%', 'P50'), ('90%', 'P90'), ('99%', 'P99')]
+        percentiles = [('50%', 'P50'), ('99%', 'P99')]
 
         groups = []
         for exp_name, df_raw in experiments_raw.items():
@@ -355,6 +355,8 @@ def main():
                     if not subset.empty:
                         phase_subsets.setdefault(pname, []).append(subset)
                 for pname, subsets in phase_subsets.items():
+                    if pname.lower() == 'warmup':
+                        continue
                     combined = pd.concat(subsets) if len(subsets) > 1 else subsets[0]
                     groups.append((combined, exp_name, pname))
 
@@ -464,7 +466,7 @@ def main():
         return fig
 
     def _make_histogram_figure(df):
-        pct_order = ['P50', 'P90', 'P99']
+        pct_order = ['P50', 'P99']
         phases = sorted(df['phase'].unique(), key=lambda p: (0 if p == 'all' else 1, p))
         all_exp_names = list(dict.fromkeys(df['experiment']))  # first-occurrence order
         exp_colors = {name: colors[i % len(colors)] for i, name in enumerate(all_exp_names)}

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -231,8 +231,10 @@ def main():
     compare_p.add_argument('--ftdc-workers', type=int, default=4, metavar='N',
                            help='Parallel workers for FTDC decoding (default: 4)')
 
-    subparsers.add_parser('histogram', parents=[common],
-                          help='Plot latency distributions grouped by phase')
+    hist_p = subparsers.add_parser('histogram', parents=[common],
+                                   help='Plot latency distributions grouped by phase')
+    hist_p.add_argument('--warmup', metavar='DIR', default=None,
+                        help='Experiment dir whose data is overlaid on all subplots as "baseline"')
 
     args = parser.parse_args()
     is_histogram = args.mode == 'histogram'
@@ -243,10 +245,15 @@ def main():
         ftdc_substrings = [s.strip() for s in args.ftdc.split(',')] if args.ftdc else []
         ftdc_mod = _import_ftdc_tools() if ftdc_substrings else None
 
+    warmup_dir = getattr(args, 'warmup', None)
+    warmup_dir_norm = os.path.normpath(warmup_dir) if warmup_dir else None
+
     experiments = {}
     experiments_raw = {}
     experiment_t0s = {}
     for exp_dir in args.experiments:
+        if warmup_dir_norm and os.path.normpath(exp_dir) == warmup_dir_norm:
+            continue  # loaded separately as baseline
         name = os.path.basename(exp_dir.rstrip('/\\'))
         print(f'Loading {name} ...')
         df, t0 = load_experiment(exp_dir, args.request_name)
@@ -255,10 +262,18 @@ def main():
             experiments[name] = bucket_data(df, args.bucket_minutes)
         experiment_t0s[name] = t0
 
+    warmup_raw = None
+    if warmup_dir:
+        wname = os.path.basename(warmup_dir.rstrip('/\\'))
+        print(f'Loading warmup baseline from {wname} ...')
+        warmup_raw, _ = load_experiment(warmup_dir, args.request_name)
+
     # Load FTDC data per experiment: {exp_name: {metric_key: {...}}}
     ftdc_by_exp = {}
     if ftdc_substrings:
         for exp_dir in args.experiments:
+            if warmup_dir_norm and os.path.normpath(exp_dir) == warmup_dir_norm:
+                continue
             name = os.path.basename(exp_dir.rstrip('/\\'))
             print(f'Loading FTDC for {name} ...')
             try:
@@ -271,6 +286,8 @@ def main():
     # Parse phase start/end times from operation logs
     experiment_phases = {}
     for exp_dir in args.experiments:
+        if warmup_dir_norm and os.path.normpath(exp_dir) == warmup_dir_norm:
+            continue
         name = os.path.basename(exp_dir.rstrip('/\\'))
         t0 = experiment_t0s[name]
         experiment_phases[name] = [(pname, (s - t0) / 3600.0,
@@ -331,7 +348,7 @@ def main():
         df = pd.concat([pd.DataFrame(phase_cols, index=df.index), df], axis=1)
         return df
 
-    def _build_histogram_dataframe():
+    def _build_histogram_dataframe(warmup_raw=None):
         """Compute histogram bins for each (percentile, phase, experiment) and return as
         long-format DataFrame with columns [percentile, phase, experiment, bin_left, bin_right,
         count].  phase='all' means no phase info (all data combined).
@@ -346,6 +363,8 @@ def main():
             else:
                 phase_subsets: dict[str, list] = {}
                 for pname, s, e in phases:
+                    if pname == 'WarmUp':
+                        continue  # never gets its own subplot
                     s_min = s * 60
                     e_min = e * 60 if e is not None else None
                     mask = df_raw['elapsed_min'] >= s_min
@@ -387,6 +406,34 @@ def main():
                         'bin_right': right,
                         'count': count,
                     })
+
+        # Inject baseline (warmup) bins into every phase subplot
+        if warmup_raw is not None:
+            all_phases = sorted(set(g[2] if g[2] is not None else 'all' for g in groups))
+            for col, pct_label in percentiles:
+                vals = warmup_raw[col].dropna()
+                if vals.empty:
+                    continue
+                lo, hi = max(0.0, float(vals.min())), float(vals.max())
+                if lo >= hi:
+                    continue
+                edges_lin = np.linspace(lo, min(x_threshold, hi), n_lin + 1)
+                if hi > x_threshold:
+                    edges_log = np.logspace(np.log10(x_threshold), np.log10(hi), n_log + 1)[1:]
+                    bin_edges = np.concatenate([edges_lin, edges_log])
+                else:
+                    bin_edges = edges_lin
+                counts, bin_edges = np.histogram(vals, bins=bin_edges)
+                for phase_val in all_phases:
+                    for left, right, count in zip(bin_edges[:-1], bin_edges[1:], counts):
+                        rows.append({
+                            'percentile': pct_label,
+                            'phase': phase_val,
+                            'experiment': 'baseline',
+                            'bin_left': left,
+                            'bin_right': right,
+                            'count': count,
+                        })
 
         return pd.DataFrame(rows,
                             columns=['percentile', 'phase', 'experiment', 'bin_left', 'bin_right',
@@ -468,7 +515,7 @@ def main():
         phase_order = ['RecordStore', 'Indexes', 'PostRun']
         phases = sorted(df['phase'].unique(),
                         key=lambda p: (phase_order.index(p) if p in phase_order else len(phase_order), p))
-        all_exp_names = list(dict.fromkeys(df['experiment']))  # first-occurrence order
+        all_exp_names = [n for n in dict.fromkeys(df['experiment']) if n != 'baseline']
         exp_colors = {name: colors[i % len(colors)] for i, name in enumerate(all_exp_names)}
 
         subplot_order = [(pct, phase) for pct in pct_order for phase in phases]
@@ -480,11 +527,19 @@ def main():
 
         for ax, (pct, phase) in zip(axes, subplot_order):
             subset = df[(df['percentile'] == pct) & (df['phase'] == phase)]
-            for exp_name, grp in subset.groupby('experiment', sort=False):
+            baseline_grp = subset[subset['experiment'] == 'baseline']
+            main_grp = subset[subset['experiment'] != 'baseline']
+            for exp_name, grp in main_grp.groupby('experiment', sort=False):
                 edges = np.append(grp['bin_left'].values, grp['bin_right'].values[-1])
                 ax.stairs(grp['count'].values, edges,
                           color=exp_colors.get(exp_name, 'gray'),
                           linewidth=1.2, label=exp_name)
+            if not baseline_grp.empty:
+                edges = np.append(baseline_grp['bin_left'].values,
+                                  baseline_grp['bin_right'].values[-1])
+                ax.stairs(baseline_grp['count'].values, edges,
+                          color='gray', linewidth=1.5, linestyle='--', alpha=0.7,
+                          label='baseline')
             phase_label = 'All data' if phase == 'all' else phase
             ax.set_title(f'{pct} — {phase_label}', fontsize=12)
             ax.set_xlabel('Latency (ms)', fontsize=11)
@@ -509,7 +564,7 @@ def main():
 
     # Step 1: Build CSV (source of truth — exact values that will be plotted)
     if is_histogram:
-        df_csv = _build_histogram_dataframe()
+        df_csv = _build_histogram_dataframe(warmup_raw=warmup_raw)
         csv_path = 'locust_latency_histogram.csv'
         df_csv.to_csv(csv_path, index=False)
         print(f'Saved: {csv_path} ({len(df_csv)} rows)')

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -24,7 +24,7 @@
 #     locust_latency.pdf           — all charts as separate pages (PDF only)
 #     locust_latency_p50.<fmt>     — one file per percentile (non-PDF formats)
 #
-#     locust_latency_histogram.csv — pre-computed KDE curves for histogram charts
+#     locust_latency_histogram.csv — pre-computed histogram bins for histogram charts
 #     locust_latency_histogram.pdf — histogram charts (--histogram mode)
 #
 # Examples:
@@ -39,7 +39,6 @@ import sys
 from datetime import datetime, timezone
 
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 import numpy as np
 import pandas as pd
 from matplotlib.backends.backend_pdf import PdfPages
@@ -333,10 +332,9 @@ def main():
         return df
 
     def _build_histogram_dataframe():
-        """Compute KDE curves for each (percentile, phase, experiment) and return as long-format
-        DataFrame with columns [percentile, phase, experiment, x, y].
-
-        phase=-1 means no phase info (all data combined). x/y are the exact values plotted.
+        """Compute histogram bins for each (percentile, phase, experiment) and return as
+        long-format DataFrame with columns [percentile, phase, experiment, bin_left, bin_right,
+        count].  phase='all' means no phase info (all data combined).
         """
         percentiles = [('50%', 'P50'), ('90%', 'P90'), ('99%', 'P99')]
 
@@ -361,31 +359,38 @@ def main():
                     groups.append((combined, exp_name, pname))
 
         x_threshold = 500
+        n_lin, n_log = 50, 30
 
         rows = []
         for col, pct_label in percentiles:
             for subset, exp_name, phase in groups:
                 vals = subset[col].dropna()
-                if vals.nunique() < 2:
+                if vals.empty:
                     continue
                 lo, hi = max(0.0, float(vals.min())), float(vals.max())
-                x_lin = np.linspace(lo, min(x_threshold, hi), 300)
-                x_log = (np.logspace(np.log10(x_threshold), np.log10(hi), 200)
-                         if hi > x_threshold else np.array([]))
-                xs = np.unique(np.concatenate([x_lin, x_log]))
-                kde = gaussian_kde(vals)
-                ys = kde(xs) * len(vals)
+                if lo >= hi:
+                    continue
+                edges_lin = np.linspace(lo, min(x_threshold, hi), n_lin + 1)
+                if hi > x_threshold:
+                    edges_log = np.logspace(np.log10(x_threshold), np.log10(hi), n_log + 1)[1:]
+                    bin_edges = np.concatenate([edges_lin, edges_log])
+                else:
+                    bin_edges = edges_lin
+                counts, bin_edges = np.histogram(vals, bins=bin_edges)
                 phase_val = 'all' if phase is None else phase
-                for x, y in zip(xs, ys):
+                for left, right, count in zip(bin_edges[:-1], bin_edges[1:], counts):
                     rows.append({
                         'percentile': pct_label,
                         'phase': phase_val,
                         'experiment': exp_name,
-                        'x': x,
-                        'y': y,
+                        'bin_left': left,
+                        'bin_right': right,
+                        'count': count,
                     })
 
-        return pd.DataFrame(rows, columns=['percentile', 'phase', 'experiment', 'x', 'y'])
+        return pd.DataFrame(rows,
+                            columns=['percentile', 'phase', 'experiment', 'bin_left', 'bin_right',
+                                     'count'])
 
     def _make_latency_figure(label, df):
         exp_names = [c.split(' / ', 1)[1] for c in df.columns if c.startswith(f'{label} /')]
@@ -470,24 +475,23 @@ def main():
         axes = np.array(axes).reshape(n_subplots)
 
         x_threshold = 500
-        y_threshold = 500
 
         for ax, (pct, phase) in zip(axes, subplot_order):
             subset = df[(df['percentile'] == pct) & (df['phase'] == phase)]
             for exp_name, grp in subset.groupby('experiment', sort=False):
-                ax.plot(grp['x'].values, grp['y'].values, color=exp_colors.get(exp_name, 'gray'),
-                        linewidth=1.0, label=exp_name)
+                edges = np.append(grp['bin_left'].values, grp['bin_right'].values[-1])
+                ax.stairs(grp['count'].values, edges,
+                          color=exp_colors.get(exp_name, 'gray'),
+                          linewidth=1.2, label=exp_name)
             phase_label = 'All data' if phase == 'all' else phase
             ax.set_title(f'{pct} — {phase_label}', fontsize=12)
             ax.set_xlabel('Latency (ms)', fontsize=11)
-            ax.set_ylabel('Samples per ms', fontsize=11)
+            ax.set_ylabel('Count', fontsize=11)
             ax.grid(True, alpha=0.3)
             ax.set_xscale('symlog', linthresh=x_threshold, linscale=1)
             ax.set_xlim(left=0)
             ax.axvline(x_threshold, color='gray', linestyle=':', linewidth=0.8, alpha=0.6)
-            ax.set_yscale('symlog', linthresh=y_threshold, linscale=1)
             ax.set_ylim(bottom=0)
-            ax.axhline(y_threshold, color='gray', linestyle=':', linewidth=0.8, alpha=0.6)
             ax.legend(fontsize=8)
 
         fig.canvas.draw()
@@ -495,8 +499,6 @@ def main():
             xticks = sorted(set(t for t in ax.get_xticks() if t >= 0) | {float(x_threshold)})
             ax.xaxis.set_major_locator(FixedLocator(xticks))
             ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{int(x):,}'))
-            yticks = sorted(set(t for t in ax.get_yticks() if t >= 0) | {float(y_threshold)})
-            ax.yaxis.set_major_locator(FixedLocator(yticks))
             ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda y, _: f'{int(y):,}'))
 
         fig.suptitle(f'Latency Histograms by Phase — {args.request_name}', fontsize=13)

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -467,7 +467,9 @@ def main():
 
     def _make_histogram_figure(df):
         pct_order = ['P50', 'P99']
-        phases = sorted(df['phase'].unique(), key=lambda p: (0 if p == 'all' else 1, p))
+        phase_order = ['RecordStore', 'Indexes', 'PostRun']
+        phases = sorted(df['phase'].unique(),
+                        key=lambda p: (phase_order.index(p) if p in phase_order else len(phase_order), p))
         all_exp_names = list(dict.fromkeys(df['experiment']))  # first-occurrence order
         exp_colors = {name: colors[i % len(colors)] for i, name in enumerate(all_exp_names)}
 

--- a/locust_workload_plot.py
+++ b/locust_workload_plot.py
@@ -396,6 +396,7 @@ def main():
                 else:
                     bin_edges = edges_lin
                 counts, bin_edges = np.histogram(vals, bins=bin_edges)
+                n_total = len(vals)
                 phase_val = 'all' if phase is None else phase
                 for left, right, count in zip(bin_edges[:-1], bin_edges[1:], counts):
                     rows.append({
@@ -404,7 +405,7 @@ def main():
                         'experiment': exp_name,
                         'bin_left': left,
                         'bin_right': right,
-                        'count': count,
+                        'count': count / n_total,
                     })
 
         # Inject baseline (warmup) bins into every phase subplot
@@ -424,6 +425,7 @@ def main():
                 else:
                     bin_edges = edges_lin
                 counts, bin_edges = np.histogram(vals, bins=bin_edges)
+                n_total = len(vals)
                 for phase_val in all_phases:
                     for left, right, count in zip(bin_edges[:-1], bin_edges[1:], counts):
                         rows.append({
@@ -432,7 +434,7 @@ def main():
                             'experiment': 'baseline',
                             'bin_left': left,
                             'bin_right': right,
-                            'count': count,
+                            'count': count / n_total,
                         })
 
         return pd.DataFrame(rows,
@@ -543,13 +545,13 @@ def main():
             phase_label = 'All data' if phase == 'all' else phase
             ax.set_title(f'{pct} — {phase_label}', fontsize=12)
             ax.set_xlabel('Latency (ms)', fontsize=11)
-            ax.set_ylabel('Count', fontsize=11)
+            ax.set_ylabel('Fraction of samples', fontsize=11)
             ax.grid(True, alpha=0.3)
             ax.set_xscale('symlog', linthresh=x_threshold, linscale=1)
             ax.set_xlim(left=0)
             ax.axvline(x_threshold, color='gray', linestyle=':', linewidth=0.8, alpha=0.6)
             ax.set_yscale('log')
-            ax.set_ylim(bottom=0.9)
+            ax.set_ylim(bottom=1e-6)
             ax.legend(fontsize=8)
 
         fig.canvas.draw()
@@ -564,7 +566,7 @@ def main():
             xticks = sorted(set(t for t in ax.get_xticks() if t >= 0) | {float(x_threshold)})
             ax.xaxis.set_major_locator(FixedLocator(xticks))
             ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{int(x):,}'))
-            ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda y, _: f'{int(y):,}'))
+            ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda y, _: f'{y:.4g}'))
 
         fig.tight_layout()
         return fig


### PR DESCRIPTION
* Add a `--warmup` optional param that introduces a "baseline" overlay to the plots. See the example below.
* Make x and y axes consistent across plots.
* Normalise distributions so that a longer run doesn't overshadow a shorter run.

```
$ ./locust_workload_plot.py histogram --warmup Runs/locust-1tb-trimTable-inplace-10pct/  Runs/locust-1tb-trimTable*
Loading locust-1tb-trimTable-inplace-10pct ...
Loading locust-1tb-trimTable-inplace-50pct ...
Loading locust-1tb-trimTable-outofplace-10pct ...
Loading locust-1tb-trimTable-outofplace-50pct ...
Loading warmup baseline from locust-1tb-trimTable-inplace-10pct ...
Saved: locust_latency_histogram.csv (2190 rows)
Saved: locust_latency_histogram.pdf
```
<img width="1236" height="1160" alt="Screenshot 2026-05-28 at 16 52 48" src="https://github.com/user-attachments/assets/b559087a-a155-4122-9d86-806624cb9db2" />
